### PR TITLE
add a prefix to the CAL_DEFAULT and CAL_GREGORIAN constants to avoid …

### DIFF
--- a/class.baserecurrence.php
+++ b/class.baserecurrence.php
@@ -169,7 +169,7 @@ abstract class BaseRecurrence {
 			return $ret;
 		}
 
-		if (!in_array($data['CalendarType'], [CAL_DEFAULT, CAL_GREGORIAN])) {
+		if (!in_array($data['CalendarType'], [MAPI_CAL_DEFAULT, MAPI_CAL_GREGORIAN])) {
 			return $ret;
 		}
 

--- a/mapidefs.php
+++ b/mapidefs.php
@@ -679,8 +679,8 @@ define('TZRULE_FLAG_RECUR_CURRENT_TZREG', 0x0001);
 define('TZRULE_FLAG_EFFECTIVE_TZREG', 0x0002);
 
 /* RecurrencePattern related values */
-define('CAL_DEFAULT', 0);
-define('CAL_GREGORIAN', 1);
+define('MAPI_CAL_DEFAULT', 0);
+define('MAPI_CAL_GREGORIAN', 1);
 define('IDC_RCEV_PAT_ORB_DAILY', 0x200A);
 define('IDC_RCEV_PAT_ORB_WEEKLY', 0x200B);
 define('IDC_RCEV_PAT_ORB_MONTHLY', 0x200C);


### PR DESCRIPTION
…conflict

the CAL_GREGORIAN constant is defined already by the php calendar extension so add a MAPI prefix to these constants to avoid conflict. php created this chaos by ignoring the fact that this should be defined to 0x1 and ignored it:

/* This conflicts with a define in winnls.h, but that header is needed
   to have GetACP(). */

/* this order must match the conversion table below */ enum cal_name_type_t {
	CAL_GREGORIAN = 0,
	CAL_JULIAN,
	CAL_JEWISH,
	CAL_FRENCH,
	CAL_NUM_CALS
};