### PR TITLE
build: preserve source file timestamps by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,11 @@ prefix = /usr
 datadir = ${prefix}/share
 pkgdatadir = ${datadir}/${PACKAGE_NAME}
 PACKAGE_NAME = php-mapi
+INSTALL = install -p
 MKDIR_P = mkdir -p
 
 all:
 
 install:
 	${MKDIR_P} ${DESTDIR}${pkgdatadir}
-	install -m0644 *.php ${DESTDIR}${pkgdatadir}/
+	${INSTALL} -m0644 *.php ${DESTDIR}${pkgdatadir}/


### PR DESCRIPTION
Some downstreams, such as Linux distributions, prefer that source file timestamps are kept during `make install` (either already by default or optionally using common parameters like `$INSTALL`).